### PR TITLE
Initialize the `@opened` instance variable

### DIFF
--- a/ext/mcrypt_wrapper.c
+++ b/ext/mcrypt_wrapper.c
@@ -127,6 +127,7 @@ static VALUE mc_initialize(int argc, VALUE *argv, VALUE self)
 
     rb_iv_set(self, "@algorithm", algo);
     rb_iv_set(self, "@mode", mode);
+    rb_iv_set(self, "@opened", TO_RB_BOOL(0));
 
     /* post-initialization stuff that's easier done in ruby */
     rb_funcall(self, rb_intern("after_init"), 3, key, iv, padding);


### PR DESCRIPTION
When running ruby in verbose mode, the warning 'instance variable @opened not initialized' is displayed.
This PR just initializes the value of `@opened` to false.